### PR TITLE
Stages 2.5-2.6: Readiness report and reference attachment

### DIFF
--- a/READINESS.md
+++ b/READINESS.md
@@ -1,0 +1,147 @@
+# Formalization Readiness Report
+
+**Generated:** 2026-03-25 (Stage 2.5)
+**Source:** `research/mathlib-coverage.json`, `research/external-sources.json`, `blobs/Chapter1/`
+
+---
+
+## Summary
+
+- **40 total items** in Chapter 1
+- **12 non-formalizable** (section intros, discussion blobs, references)
+- **28 formalizable** items (definitions, theorems, lemmas, propositions, examples, remarks)
+  - **20 fully covered** by Mathlib — these can be formalized as wrappers or existence proofs pointing at Mathlib
+  - **6 partially covered** by Mathlib — require original proof work for gaps
+  - **2 require entirely original work** (no Mathlib coverage, but external sources available)
+
+---
+
+## Non-Formalizable Items (skip in Phase 3)
+
+These are discussion blobs, section introductions, or reference lists with no mathematical content to formalize.
+
+| ID | Reason |
+|----|--------|
+| Chapter1/Introduction | Narrative introduction |
+| Chapter1/Remark1_1 | Motivational context, no formalizable statement |
+| Chapter1/Section1_2_Intro | Section heading text |
+| Chapter1/Section1_3_Intro | Section heading text |
+| Chapter1/Section1_4_Intro | Section heading text |
+| Chapter1/Section1_5_Intro | Section heading text |
+| Chapter1/Section1_6_Intro | Section heading text |
+| Chapter1/Discussion_after_Definition1_10 | Explanatory prose |
+| Chapter1/Discussion_after_Definition1_11 | Explanatory prose |
+| Chapter1/Discussion_after_Definition1_13 | Explanatory prose |
+| Chapter1/Discussion_after_Example1_24 | Explanatory prose |
+| Chapter1/References | Bibliography |
+
+---
+
+## Ready to Formalize — Full Mathlib Coverage
+
+These items can be formalized immediately by writing Lean statements that use (or mirror) the corresponding Mathlib declarations. No new mathematical work is required.
+
+| ID | Key Mathlib Declarations |
+|----|--------------------------|
+| Chapter1/Definition1_2 | `AbsoluteValue`, `IsNonarchimedean` |
+| Chapter1/Example1_3 | `AbsoluteValue.abs`, `AbsoluteValue.trivial`, `Rat.AbsoluteValue.padic` |
+| Chapter1/Definition1_6 | `AbsoluteValue.IsEquiv` |
+| Chapter1/Definition1_7 | `padicValNat`, `padicNorm`, `Rat.AbsoluteValue.padic` |
+| Chapter1/Theorem1_8 | `Rat.AbsoluteValue.equiv_real_or_padic` (Ostrowski) |
+| Chapter1/Theorem1_9 | `NumberField.prod_abs_eq_one` (product formula) |
+| Chapter1/Definition1_10 | `Valuation`, `IsDiscreteValuationRing`, `Valuation.integer` |
+| Chapter1/Definition1_11 | `ValuationRing` |
+| Chapter1/Definition1_12 | `IsLocalRing` |
+| Chapter1/Definition1_13 | `IsLocalRing.ResidueField` |
+| Chapter1/Definition1_17 | `IsIntegral`, `Algebra.IsIntegral` |
+| Chapter1/Proposition1_18 | `IsIntegral.add`, `IsIntegral.mul` |
+| Chapter1/Definition1_19 | `integralClosure`, `IsIntegrallyClosed` |
+| Chapter1/Proposition1_20 | `Algebra.IsIntegral.trans` |
+| Chapter1/Corollary1_21 | `integralClosure.isIntegrallyClosedOfFiniteExtension` |
+| Chapter1/Proposition1_22 | `GCDMonoid.toIsIntegrallyClosed`, `Int.instIsIntegrallyClosed` |
+| Chapter1/Corollary1_23 | `GCDMonoid.toIsIntegrallyClosed`, `UniqueFactorizationMonoid.instGCDMonoid` |
+| Chapter1/Proposition1_25 | `Valuation.isIntegrallyClosed` |
+| Chapter1/Definition1_26 | `NumberField`, `RingOfIntegers` |
+| Chapter1/Proposition1_28 | `IsIntegrallyClosed.isIntegral_iff_leadingCoeff_dvd` |
+
+---
+
+## Needs Original Work — Partial Mathlib Coverage
+
+These items have Mathlib support for part of the statement but require original proof work for the gaps. See the corresponding `.refs.md` files for details.
+
+| ID | What Needs Original Work |
+|----|--------------------------|
+| Chapter1/Lemma1_4 | Converse direction: `\|n\| ≤ 1` for all n ∈ ℕ ⟹ absolute value is non-archimedean. Forward direction is in Mathlib. |
+| Chapter1/Corollary1_5 | Full statement: pos. characteristic ⟹ non-archimedean; finite field ⟹ only trivial abs. value. Depends on Lemma1_4. |
+| Chapter1/Example1_14 | Explicit identification of maximal ideal and residue field of ℤ_(p). Construction is in Mathlib. |
+| Chapter1/Example1_15 | Assembling t-adic valuation on k((t)) from `PowerSeries.order`; the DVR structure of k[[t]]. |
+| Chapter1/Theorem1_16 | 7-way DVR characterization. Multiple Mathlib lemmas cover subsets; full equivalence needs assembly. |
+| Chapter1/Remark1_27 | 𝒪_K as free ℤ-module of rank [K:ℚ] (finiteness). Integrally closed part is in Mathlib; order/freeness is partial. |
+
+---
+
+## Needs Original Work — No Mathlib Coverage
+
+These items require concrete computations with no direct Mathlib theorem. External sources are available in the `.refs.md` files.
+
+| ID | What Needs Original Work |
+|----|--------------------------|
+| Chapter1/Example1_24 | Show (1+√5)/2 is integral over ℤ but not in ℤ[√5]. Concrete algebraic computation. |
+| Chapter1/Example1_29 | Show (1+√7)/2 has minimal polynomial x²−x−3/2 ∉ ℤ[x] (hence not integral over ℤ). Concrete computation. |
+
+---
+
+## Suggested Formalization Order
+
+Follow the book order within each tier. Items earlier in the list unblock later items.
+
+**Tier 1 — Foundations (no dependencies on earlier Chapter 1 items):**
+1. Definition1_2 (absolute values — central definition of §1.2)
+2. Example1_3 (standard, trivial, p-adic abs. values)
+3. Definition1_6 (equivalence of absolute values)
+4. Definition1_7 (p-adic valuation and absolute value on ℚ)
+5. Theorem1_8 (Ostrowski's theorem for ℚ — can reuse Mathlib directly)
+6. Theorem1_9 (product formula — can reuse Mathlib directly)
+7. Definition1_10 (valuations and DVRs)
+8. Definition1_11 (valuation rings)
+9. Definition1_12 (local rings)
+10. Definition1_13 (residue fields)
+
+**Tier 2 — Absolute value theory (depends on Def1_2/Def1_7):**
+11. Lemma1_4 (characterization of non-archimedean — needs original proof of converse)
+12. Corollary1_5 (depends on Lemma1_4)
+
+**Tier 3 — DVR theory (depends on Def1_10–Def1_13):**
+13. Example1_14 (ℤ_(p) as a local ring with residue field 𝔽_p)
+14. Example1_15 (k[[t]] as a DVR)
+15. Theorem1_16 (DVR characterizations — complex assembly from Mathlib)
+
+**Tier 4 — Integral closure (independent of §§1.2–1.5):**
+16. Definition1_17 (integral elements)
+17. Proposition1_18 (sum and product of integral elements are integral)
+18. Definition1_19 (integral closure, integrally closed rings)
+19. Proposition1_20 (transitivity of integrality)
+20. Corollary1_21 (integral closure is integrally closed)
+21. Proposition1_22 (ℤ is integrally closed)
+22. Corollary1_23 (UFD ⟹ integrally closed)
+23. Example1_24 (ℤ[√5] not integrally closed — needs computation)
+24. Proposition1_25 (valuation rings are integrally closed)
+25. Definition1_26 (number fields and rings of integers)
+26. Remark1_27 (𝒪_K is a free ℤ-module of rank [K:ℚ])
+27. Proposition1_28 (α integral iff min. poly. in A[x])
+28. Example1_29 (depends on Proposition1_28)
+
+---
+
+## Concerns / Infrastructure Notes
+
+1. **Theorem1_16 complexity:** The 7-way DVR equivalence is the most complex single item. It requires assembling results from `DiscreteValuationRing.Basic`, `DedekindDomain.DVR`, and possibly `RingTheory.Noetherian`. A dedicated sub-issue with careful decomposition is recommended.
+
+2. **Lemma1_4 converse:** The converse direction (|n| ≤ 1 for all n ⟹ non-archimedean) is not a standalone Mathlib lemma. It appears inside Ostrowski's proof. The proof strategy is in `blobs/Chapter1/Lemma1_4.refs.md`: use the binomial theorem with a limit argument.
+
+3. **Example1_24 and Example1_29:** These are concrete algebraic computations in ℤ[√5] and ℤ[√7]. Lean's `norm_num` or `decide` may handle them, but the ring ℤ[√d] may need to be set up explicitly using `Zsqrtd` from Mathlib.
+
+4. **Remark1_27 freeness:** The fact that 𝒪_K is a free ℤ-module of rank [K:ℚ] (`NumberField.RingOfIntegers.rank`) is in Mathlib but may need careful instance assembly. The "order" concept (sub-ℤ-algebra of finite rank) is not a standalone Mathlib typeclass.
+
+5. **Book-vs-Mathlib API alignment:** Several definitions (especially `AbsoluteValue`, `Valuation`) use bundled structures in Mathlib that may differ slightly from the lecture's formulation. Formalization agents should read the `.refs.md` notes carefully before choosing statement forms.

--- a/blobs/Chapter1/Corollary1_21.refs.md
+++ b/blobs/Chapter1/Corollary1_21.refs.md
@@ -1,0 +1,12 @@
+# References for Corollary1_21
+
+## Mathlib Coverage
+
+**Status:** full
+
+The corollary (integral closure is integrally closed) is in Mathlib.
+
+### Relevant Declarations
+
+- `integralClosure.isIntegrallyClosedOfFiniteExtension` (Mathlib.RingTheory.IntegralClosure.IntegrallyClosed)
+  The integral closure of R in a finite extension L is integrally closed in L.

--- a/blobs/Chapter1/Corollary1_23.refs.md
+++ b/blobs/Chapter1/Corollary1_23.refs.md
@@ -1,0 +1,15 @@
+# References for Corollary1_23
+
+## Mathlib Coverage
+
+**Status:** full
+
+UFD ⟹ integrally closed follows from these two instances.
+
+### Relevant Declarations
+
+- `GCDMonoid.toIsIntegrallyClosed` (Mathlib.Algebra.GCDMonoid.IntegrallyClosed)
+  Every GCDMonoid (which includes all UFDs) is integrally closed.
+
+- `UniqueFactorizationMonoid.instGCDMonoid` (Mathlib.Algebra.GCDMonoid.Basic)
+  Every UFD is a GCDMonoid.

--- a/blobs/Chapter1/Corollary1_5.refs.md
+++ b/blobs/Chapter1/Corollary1_5.refs.md
@@ -1,0 +1,22 @@
+# References for Corollary1_5
+
+## Mathlib Coverage
+
+**Status:** partial
+
+The corollary (positive characteristic ⟹ all absolute values non-archimedean; finite field ⟹ only trivial absolute value) does not have a direct Mathlib theorem. Follows from Lemma1_4 + CharP facts. Needs to be formalized here.
+
+### Relevant Declarations
+
+- `CharP.cast_eq_zero_iff` (Mathlib.Algebra.CharP.Defs)
+  Character of a ring; used to show n · 1 = 0 in positive characteristic.
+
+## Gaps / Original Work Needed
+
+- The statement: every absolute value on a field of positive characteristic is non-archimedean
+- The statement: the only absolute value on a finite field is the trivial one
+
+## External Sources
+
+- **Neukirch, Algebraic Number Theory, Chapter II §1, Remark after Def 1.1**
+  Standard result: in characteristic p, n·1 = 0 for some n ≥ 1, so |n| = 0. Then Lemma1_4 applies.

--- a/blobs/Chapter1/Definition1_10.refs.md
+++ b/blobs/Chapter1/Definition1_10.refs.md
@@ -1,0 +1,18 @@
+# References for Definition1_10
+
+## Mathlib Coverage
+
+**Status:** full
+
+Valuation and DVR are both fully covered in Mathlib.
+
+### Relevant Declarations
+
+- `Valuation` (Mathlib.RingTheory.Valuation.Basic)
+  Structure for valuations: ring homomorphism k× → Γ₀ satisfying v(x+y) ≥ min(v(x),v(y)). Discrete valuations use Γ₀ = ℤ with WithTop.
+
+- `IsDiscreteValuationRing` (Mathlib.RingTheory.DiscreteValuationRing.Basic)
+  Class for DVRs: local PID that is not a field.
+
+- `Valuation.integer` (Mathlib.RingTheory.Valuation.Basic)
+  The valuation ring {x : k | v(x) ≥ 0} of a valuation v on a field k.

--- a/blobs/Chapter1/Definition1_11.refs.md
+++ b/blobs/Chapter1/Definition1_11.refs.md
@@ -1,0 +1,15 @@
+# References for Definition1_11
+
+## Mathlib Coverage
+
+**Status:** full
+
+ValuationRing matches the lecture definition (A is a valuation ring iff for all x ∈ K, x ∈ A or x⁻¹ ∈ A).
+
+### Relevant Declarations
+
+- `ValuationRing` (Mathlib.RingTheory.Valuation.ValuationRing)
+  Class: integral domain where for any pair of elements, one divides the other (equivalently: for all x in FracField, x ∈ A or x⁻¹ ∈ A).
+
+- `PreValuationRing` (Mathlib.RingTheory.Valuation.ValuationRing)
+  Weaker version without domain assumption.

--- a/blobs/Chapter1/Definition1_12.refs.md
+++ b/blobs/Chapter1/Definition1_12.refs.md
@@ -1,0 +1,12 @@
+# References for Definition1_12
+
+## Mathlib Coverage
+
+**Status:** full
+
+Local ring is fully covered.
+
+### Relevant Declarations
+
+- `IsLocalRing` (Mathlib.RingTheory.LocalRing.Defs)
+  Class: nontrivial ring where for every a, either a or 1-a is a unit. Equivalent to having a unique maximal ideal.

--- a/blobs/Chapter1/Definition1_13.refs.md
+++ b/blobs/Chapter1/Definition1_13.refs.md
@@ -1,0 +1,15 @@
+# References for Definition1_13
+
+## Mathlib Coverage
+
+**Status:** full
+
+Residue field is fully covered.
+
+### Relevant Declarations
+
+- `IsLocalRing.ResidueField` (Mathlib.RingTheory.LocalRing.ResidueField.Defs)
+  Definition: R ⧸ maximalIdeal R as a field.
+
+- `IsLocalRing.residue` (Mathlib.RingTheory.LocalRing.ResidueField.Defs)
+  The quotient map R →+* ResidueField R.

--- a/blobs/Chapter1/Definition1_17.refs.md
+++ b/blobs/Chapter1/Definition1_17.refs.md
@@ -1,0 +1,15 @@
+# References for Definition1_17
+
+## Mathlib Coverage
+
+**Status:** full
+
+Full Mathlib coverage.
+
+### Relevant Declarations
+
+- `IsIntegral` (Mathlib.RingTheory.IntegralClosure.IsIntegral.Defs)
+  Predicate: IsIntegral R x holds if x is a root of a monic polynomial with coefficients in R.
+
+- `Algebra.IsIntegral` (Mathlib.RingTheory.IntegralClosure.IsIntegral.Defs)
+  Class: all elements of an algebra are integral.

--- a/blobs/Chapter1/Definition1_19.refs.md
+++ b/blobs/Chapter1/Definition1_19.refs.md
@@ -1,0 +1,15 @@
+# References for Definition1_19
+
+## Mathlib Coverage
+
+**Status:** full
+
+Full Mathlib coverage.
+
+### Relevant Declarations
+
+- `integralClosure` (Mathlib.RingTheory.IntegralClosure.IsIntegral.Defs)
+  The integral closure of R in A: subalgebra of all elements of A that are integral over R.
+
+- `IsIntegrallyClosed` (Mathlib.RingTheory.IntegralClosure.IntegrallyClosed)
+  Predicate: R is integrally closed in its fraction field (all elements of Frac(R) integral over R lie in R).

--- a/blobs/Chapter1/Definition1_2.refs.md
+++ b/blobs/Chapter1/Definition1_2.refs.md
@@ -1,0 +1,15 @@
+# References for Definition1_2
+
+## Mathlib Coverage
+
+**Status:** full
+
+AbsoluteValue covers both archimedean and non-archimedean cases; IsNonarchimedean captures the extra condition.
+
+### Relevant Declarations
+
+- `AbsoluteValue` (Mathlib.Algebra.Order.AbsoluteValue.Basic)
+  Bundled structure for absolute values on a semiring R mapping to an ordered semiring S. Satisfies nonneg, eq_zero iff zero, mul_map, and triangle inequality.
+
+- `IsNonarchimedean` (Mathlib.Algebra.Order.Ring.IsNonarchimedean)
+  Predicate `IsNonarchimedean f` for the strong triangle inequality f(a+b) ≤ max(f a, f b).

--- a/blobs/Chapter1/Definition1_26.refs.md
+++ b/blobs/Chapter1/Definition1_26.refs.md
@@ -1,0 +1,15 @@
+# References for Definition1_26
+
+## Mathlib Coverage
+
+**Status:** full
+
+Number fields and their rings of integers are fully covered in Mathlib.
+
+### Relevant Declarations
+
+- `NumberField` (Mathlib.NumberTheory.NumberField.Basic)
+  Class: a field K with CharZero and [FiniteDimensional ℚ K] — i.e. a finite extension of ℚ.
+
+- `RingOfIntegers` (Mathlib.NumberTheory.NumberField.Basic)
+  Definition: 𝓞 K = integralClosure ℤ K, the ring of integers of the number field K.

--- a/blobs/Chapter1/Definition1_6.refs.md
+++ b/blobs/Chapter1/Definition1_6.refs.md
@@ -1,0 +1,12 @@
+# References for Definition1_6
+
+## Mathlib Coverage
+
+**Status:** full
+
+IsEquiv formalizes the equivalence relation on absolute values.
+
+### Relevant Declarations
+
+- `AbsoluteValue.IsEquiv` (Mathlib.Algebra.Order.AbsoluteValue.Basic)
+  Two absolute values are equivalent if one is a positive real power of the other.

--- a/blobs/Chapter1/Definition1_7.refs.md
+++ b/blobs/Chapter1/Definition1_7.refs.md
@@ -1,0 +1,24 @@
+# References for Definition1_7
+
+## Mathlib Coverage
+
+**Status:** full
+
+Full Mathlib coverage of the p-adic valuation and absolute value on ℚ.
+
+### Relevant Declarations
+
+- `padicValNat` (Mathlib.NumberTheory.Padics.PadicVal.Defs)
+  p-adic valuation on ℕ: padicValNat p n is the exponent of p in n.
+
+- `padicValInt` (Mathlib.NumberTheory.Padics.PadicVal.Defs)
+  p-adic valuation on ℤ.
+
+- `padicValRat` (Mathlib.NumberTheory.Padics.PadicVal.Defs)
+  p-adic valuation on ℚ (as an integer-valued function).
+
+- `padicNorm` (Mathlib.NumberTheory.Padics.PadicNorm)
+  The p-adic absolute value |x|_p = p^(-v_p(x)) on ℚ.
+
+- `Rat.AbsoluteValue.padic` (Mathlib.NumberTheory.Ostrowski)
+  The p-adic absolute value packaged as AbsoluteValue ℚ ℝ.

--- a/blobs/Chapter1/Example1_14.refs.md
+++ b/blobs/Chapter1/Example1_14.refs.md
@@ -1,0 +1,15 @@
+# References for Example1_14
+
+## Mathlib Coverage
+
+**Status:** partial
+
+The construction of ℤ_(p) as a localization is in Mathlib; the identification of maximal ideal as (p) and residue field as 𝔽_p needs to be made explicit.
+
+### Relevant Declarations
+
+- `Localization.AtPrime` (Mathlib.RingTheory.Localization.AtPrime)
+  The localization of ℤ at a prime ideal (p), giving ℤ_(p) = {a/b : p ∤ b}.
+
+- `IsLocalRing.ResidueField` (Mathlib.RingTheory.LocalRing.ResidueField.Defs)
+  The residue field of ℤ_(p) is ℤ/pℤ ≅ 𝔽_p.

--- a/blobs/Chapter1/Example1_15.refs.md
+++ b/blobs/Chapter1/Example1_15.refs.md
@@ -1,0 +1,18 @@
+# References for Example1_15
+
+## Mathlib Coverage
+
+**Status:** partial
+
+Basic constructions are in Mathlib. The specific valuation on k((t)) with value group ℤ and valuation ring k[[t]] can be assembled from these pieces.
+
+### Relevant Declarations
+
+- `PowerSeries` (Mathlib.RingTheory.PowerSeries.Basic)
+  Formal power series ring k[[t]].
+
+- `LaurentSeries` (Mathlib.RingTheory.LaurentSeries)
+  Laurent series field k((t)) = fraction field of k[[t]].
+
+- `PowerSeries.order` (Mathlib.RingTheory.PowerSeries.Order)
+  Order of vanishing at 0 for a power series; gives the t-adic valuation.

--- a/blobs/Chapter1/Example1_24.refs.md
+++ b/blobs/Chapter1/Example1_24.refs.md
@@ -1,0 +1,10 @@
+# References for Example1_24
+
+## Gaps / Original Work Needed
+
+- Concrete computation: (1+√5)/2 satisfies x² - x - 1 = 0 (integral over ℤ), but is not in ℤ[√5]
+
+## External Sources
+
+- **Sutherland lecture notes, Example 1.24**
+  The computation x = (1+√5)/2 satisfies x² - x - 1 = 0 showing integrality over ℤ; then argue it lies in the integral closure ℤ[(1+√5)/2] ⊃ ℤ[√5], showing ℤ[√5] ≠ its own integral closure.

--- a/blobs/Chapter1/Example1_29.refs.md
+++ b/blobs/Chapter1/Example1_29.refs.md
@@ -1,0 +1,10 @@
+# References for Example1_29
+
+## Gaps / Original Work Needed
+
+- Concrete computation: α = (1+√7)/2 has minimal polynomial x² - x - 3/2 ∉ ℤ[x]
+
+## External Sources
+
+- **Sutherland lecture notes, Example 1.29**
+  Compute: α = (1+√7)/2, α² = (1+2√7+7)/4 = (8+2√7)/4 = 2 + √7/2. Then α² - α = 2 + √7/2 - 1/2 - √7/2 = 3/2. So α satisfies x² - x - 3/2 = 0. Since the constant term 3/2 ∉ ℤ, the min poly has non-integer coefficients and α is not integral over ℤ.

--- a/blobs/Chapter1/Example1_3.refs.md
+++ b/blobs/Chapter1/Example1_3.refs.md
@@ -1,0 +1,18 @@
+# References for Example1_3
+
+## Mathlib Coverage
+
+**Status:** full
+
+Examples of absolute values: standard |·|_∞, trivial, and p-adic.
+
+### Relevant Declarations
+
+- `AbsoluteValue.abs` (Mathlib.Algebra.Order.AbsoluteValue.Basic)
+  Standard absolute value on a linear ordered field.
+
+- `AbsoluteValue.trivial` (Mathlib.Algebra.Order.AbsoluteValue.Basic)
+  The trivial absolute value (0 ↦ 0, else 1).
+
+- `Rat.AbsoluteValue.padic` (Mathlib.NumberTheory.Ostrowski)
+  The p-adic absolute value on ℚ as an AbsoluteValue ℚ ℝ.

--- a/blobs/Chapter1/Lemma1_4.refs.md
+++ b/blobs/Chapter1/Lemma1_4.refs.md
@@ -1,0 +1,27 @@
+# References for Lemma1_4
+
+## Mathlib Coverage
+
+**Status:** partial
+
+The forward direction (non-arch ⟹ |n|≤1 for all n) is in Mathlib. The converse (|n|≤1 for all n ⟹ non-arch) appears implicitly in Ostrowski's proof but is not a standalone lemma. Needs to be formalized here.
+
+### Relevant Declarations
+
+- `IsNonarchimedean.apply_natCast_le_one_of_isNonarchimedean` (Mathlib.Algebra.Order.Ring.IsNonarchimedean)
+  Forward direction: if f is nonarchimedean with f 1 = 1 then f (n : ℕ) ≤ 1 for all n.
+
+- `AbsoluteValue.IsNontrivial` (Mathlib.NumberTheory.Ostrowski)
+  Used in Ostrowski's theorem; the bounded-on-naturals condition appears in the proof.
+
+## Gaps / Original Work Needed
+
+- The converse direction: |n| ≤ 1 for all n ∈ ℕ ⟹ absolute value is non-archimedean
+
+## External Sources
+
+- **Neukirch, Algebraic Number Theory, Chapter II §1**
+  Standard proof: if |n| ≤ 1 for all n, then by binomial theorem |x+y|^N = |(x+y)^N| = |∑ C(N,k) x^k y^(N-k)| ≤ (N+1) max(|x|,|y|)^N; take N-th roots and N→∞.
+
+- **Conrad, K. 'Ostrowski's Theorem for Q' (expository notes)** — https://kconrad.math.uconn.edu/blurbs/gradnumthy/ostrowskilocal.pdf
+  Contains the lemma and its converse.

--- a/blobs/Chapter1/Proposition1_18.refs.md
+++ b/blobs/Chapter1/Proposition1_18.refs.md
@@ -1,0 +1,15 @@
+# References for Proposition1_18
+
+## Mathlib Coverage
+
+**Status:** full
+
+The lecture proof uses algebraic closure and symmetric polynomials (external deps); Mathlib's proofs are self-contained and direct.
+
+### Relevant Declarations
+
+- `IsIntegral.add` (Mathlib.RingTheory.IntegralClosure.Algebra.Basic)
+  If x and y are integral over R, then x + y is integral over R.
+
+- `IsIntegral.mul` (Mathlib.RingTheory.IntegralClosure.Algebra.Basic)
+  If x and y are integral over R, then x * y is integral over R.

--- a/blobs/Chapter1/Proposition1_20.refs.md
+++ b/blobs/Chapter1/Proposition1_20.refs.md
@@ -1,0 +1,12 @@
+# References for Proposition1_20
+
+## Mathlib Coverage
+
+**Status:** full
+
+Transitivity of integrality is fully in Mathlib.
+
+### Relevant Declarations
+
+- `Algebra.IsIntegral.trans` (Mathlib.RingTheory.IntegralClosure.IsIntegralClosure.Basic)
+  If B is integral over A and C is integral over B, then C is integral over A (transitivity of integrality).

--- a/blobs/Chapter1/Proposition1_22.refs.md
+++ b/blobs/Chapter1/Proposition1_22.refs.md
@@ -1,0 +1,15 @@
+# References for Proposition1_22
+
+## Mathlib Coverage
+
+**Status:** full
+
+ℤ is a GCDMonoid in Mathlib, so IsIntegrallyClosed ℤ follows automatically. The lecture proves it directly using the rational root test.
+
+### Relevant Declarations
+
+- `GCDMonoid.toIsIntegrallyClosed` (Mathlib.Algebra.GCDMonoid.IntegrallyClosed)
+  Every GCD monoid (in particular every UFD, and hence every PID, and hence ℤ) is integrally closed.
+
+- `Int.instIsIntegrallyClosed` (Mathlib.Algebra.GCDMonoid.IntegrallyClosed)
+  Instance: ℤ is integrally closed (derived from GCDMonoid).

--- a/blobs/Chapter1/Proposition1_25.refs.md
+++ b/blobs/Chapter1/Proposition1_25.refs.md
@@ -1,0 +1,15 @@
+# References for Proposition1_25
+
+## Mathlib Coverage
+
+**Status:** full
+
+Full Mathlib coverage.
+
+### Relevant Declarations
+
+- `Valuation.isIntegrallyClosed` (Mathlib.RingTheory.Valuation.Integral)
+  The valuation ring of a valuation is integrally closed.
+
+- `Valuation.isIntegrallyClosed_integers` (Mathlib.RingTheory.Valuation.Integral)
+  Instance: the integer ring (valuation ring) of a valuation is integrally closed.

--- a/blobs/Chapter1/Proposition1_28.refs.md
+++ b/blobs/Chapter1/Proposition1_28.refs.md
@@ -1,0 +1,18 @@
+# References for Proposition1_28
+
+## Mathlib Coverage
+
+**Status:** full
+
+The key result (α integral over A iff min poly ∈ A[x]) is covered by these lemmas.
+
+### Relevant Declarations
+
+- `minpoly.isIntegrallyClosed_eq_field_fractions` (Mathlib.FieldTheory.Minpoly.IsIntegrallyClosed)
+  For integrally closed R, if s is integral over R and K = Frac(R), then minpoly K s = (minpoly R s).map (algebraMap R K).
+
+- `IsIntegrallyClosed.isIntegral_iff_leadingCoeff_dvd` (Mathlib.FieldTheory.Minpoly.IsIntegrallyClosed)
+  For integrally closed R with fraction field K, x ∈ L is integral over R iff the minimal polynomial of x over K has coefficients in R.
+
+- `IsIntegrallyClosed.minpoly.unique` (Mathlib.FieldTheory.Minpoly.IsIntegrallyClosed)
+  Characterizes the minimal polynomial over an integrally closed ring.

--- a/blobs/Chapter1/Remark1_27.refs.md
+++ b/blobs/Chapter1/Remark1_27.refs.md
@@ -1,0 +1,25 @@
+# References for Remark1_27
+
+## Mathlib Coverage
+
+**Status:** partial
+
+The remark discusses 𝒪_K as the maximal order (free ℤ-module of rank [K:ℚ]). The finiteness/freeness of 𝒪_K as a ℤ-module is in Mathlib. The 'order' concept (sub-ℤ-algebra that is a free ℤ-module of rank n) is not a standalone Mathlib type.
+
+### Relevant Declarations
+
+- `NumberField.RingOfIntegers.isIntegrallyClosed` (Mathlib.NumberTheory.NumberField.Basic)
+  𝓞 K is integrally closed in K.
+
+## Gaps / Original Work Needed
+
+- Formalization of the concept of an 'order' in a finite-dimensional ℚ-algebra (sub-ℤ-algebra that is a free ℤ-module of rank [K:ℚ])
+- Proof that 𝒪_K is a maximal order
+
+## External Sources
+
+- **Neukirch, Algebraic Number Theory, Chapter I §2**
+  Detailed treatment of orders in number fields.
+
+- **Cohen, A Course in Computational Algebraic Number Theory, Chapter 2**
+  Computational perspective on orders.

--- a/blobs/Chapter1/Theorem1_16.refs.md
+++ b/blobs/Chapter1/Theorem1_16.refs.md
@@ -1,0 +1,30 @@
+# References for Theorem1_16
+
+## Mathlib Coverage
+
+**Status:** partial
+
+Several of the equivalences in Theorem 1.16 are provable from Mathlib. The full 7-way equivalence stated in the lecture needs to be assembled from multiple Mathlib lemmas.
+
+### Relevant Declarations
+
+- `IsDiscreteValuationRing` (Mathlib.RingTheory.DiscreteValuationRing.Basic)
+  The DVR class in Mathlib is defined as: local PID that is not a field.
+
+- `DiscreteValuationRing.iff_pid_with_one_nonzero_prime` (Mathlib.RingTheory.DiscreteValuationRing.Basic)
+  DVR iff PID with unique nonzero prime ideal.
+
+- `IsDedekindDomain.isDVR_of_onlyOnePrime` (Mathlib.RingTheory.DedekindDomain.DVR)
+  Characterizes DVRs among Dedekind domains (noetherian integrally closed dim ≤ 1).
+
+## Gaps / Original Work Needed
+
+- The full 7-way equivalence for DVRs as stated in the lecture. Mathlib has several of these but not all bundled as a single theorem.
+
+## External Sources
+
+- **Sutherland lecture notes, Theorem 1.16**
+  The proof of each equivalence is standard algebra. Mathlib contains: DVR = local PID (the base definition), and can build the characterization via Noetherian valuation rings, integrally closed Noetherian local rings of dimension 1, regular Noetherian local rings of dimension 1.
+
+- **Serre, Local Fields, Chapter I**
+  Detailed treatment of DVR characterizations.

--- a/blobs/Chapter1/Theorem1_8.refs.md
+++ b/blobs/Chapter1/Theorem1_8.refs.md
@@ -1,0 +1,12 @@
+# References for Theorem1_8
+
+## Mathlib Coverage
+
+**Status:** full
+
+Ostrowski's theorem is fully proved in Mathlib for ℚ.
+
+### Relevant Declarations
+
+- `Rat.AbsoluteValue.equiv_real_or_padic` (Mathlib.NumberTheory.Ostrowski)
+  Ostrowski's theorem: every nontrivial absolute value on ℚ is equivalent to |·|_∞ or |·|_p for some prime p.

--- a/blobs/Chapter1/Theorem1_9.refs.md
+++ b/blobs/Chapter1/Theorem1_9.refs.md
@@ -1,0 +1,12 @@
+# References for Theorem1_9
+
+## Mathlib Coverage
+
+**Status:** full
+
+The product formula for ℚ is a special case of the number field product formula. The lecture statement (∏_{p≤∞} |x|_p = 1 for x ∈ ℚ×) follows directly.
+
+### Relevant Declarations
+
+- `NumberField.prod_abs_eq_one` (Mathlib.NumberTheory.NumberField.ProductFormula)
+  Product formula for number fields: for nonzero x in K, the product over all places of the normalized absolute value |x|_v equals 1.

--- a/progress/items.json
+++ b/progress/items.json
@@ -1,42 +1,162 @@
 [
-  {"id": "Chapter1/Introduction", "status": "blob_extracted"},
-  {"id": "Chapter1/Remark1_1", "status": "blob_extracted"},
-  {"id": "Chapter1/Section1_2_Intro", "status": "blob_extracted"},
-  {"id": "Chapter1/Definition1_2", "status": "blob_extracted"},
-  {"id": "Chapter1/Example1_3", "status": "blob_extracted"},
-  {"id": "Chapter1/Lemma1_4", "status": "blob_extracted"},
-  {"id": "Chapter1/Corollary1_5", "status": "blob_extracted"},
-  {"id": "Chapter1/Definition1_6", "status": "blob_extracted"},
-  {"id": "Chapter1/Section1_3_Intro", "status": "blob_extracted"},
-  {"id": "Chapter1/Definition1_7", "status": "blob_extracted"},
-  {"id": "Chapter1/Theorem1_8", "status": "blob_extracted"},
-  {"id": "Chapter1/Theorem1_9", "status": "blob_extracted"},
-  {"id": "Chapter1/Section1_4_Intro", "status": "blob_extracted"},
-  {"id": "Chapter1/Definition1_10", "status": "blob_extracted"},
-  {"id": "Chapter1/Discussion_after_Definition1_10", "status": "blob_extracted"},
-  {"id": "Chapter1/Definition1_11", "status": "blob_extracted"},
-  {"id": "Chapter1/Discussion_after_Definition1_11", "status": "blob_extracted"},
-  {"id": "Chapter1/Definition1_12", "status": "blob_extracted"},
-  {"id": "Chapter1/Definition1_13", "status": "blob_extracted"},
-  {"id": "Chapter1/Discussion_after_Definition1_13", "status": "blob_extracted"},
-  {"id": "Chapter1/Example1_14", "status": "blob_extracted"},
-  {"id": "Chapter1/Example1_15", "status": "blob_extracted"},
-  {"id": "Chapter1/Section1_5_Intro", "status": "blob_extracted"},
-  {"id": "Chapter1/Theorem1_16", "status": "blob_extracted"},
-  {"id": "Chapter1/Section1_6_Intro", "status": "blob_extracted"},
-  {"id": "Chapter1/Definition1_17", "status": "blob_extracted"},
-  {"id": "Chapter1/Proposition1_18", "status": "blob_extracted"},
-  {"id": "Chapter1/Definition1_19", "status": "blob_extracted"},
-  {"id": "Chapter1/Proposition1_20", "status": "blob_extracted"},
-  {"id": "Chapter1/Corollary1_21", "status": "blob_extracted"},
-  {"id": "Chapter1/Proposition1_22", "status": "blob_extracted"},
-  {"id": "Chapter1/Corollary1_23", "status": "blob_extracted"},
-  {"id": "Chapter1/Example1_24", "status": "blob_extracted"},
-  {"id": "Chapter1/Discussion_after_Example1_24", "status": "blob_extracted"},
-  {"id": "Chapter1/Proposition1_25", "status": "blob_extracted"},
-  {"id": "Chapter1/Definition1_26", "status": "blob_extracted"},
-  {"id": "Chapter1/Remark1_27", "status": "blob_extracted"},
-  {"id": "Chapter1/Proposition1_28", "status": "blob_extracted"},
-  {"id": "Chapter1/Example1_29", "status": "blob_extracted"},
-  {"id": "Chapter1/References", "status": "blob_extracted"}
+  {
+    "id": "Chapter1/Introduction",
+    "status": "extracted"
+  },
+  {
+    "id": "Chapter1/Remark1_1",
+    "status": "extracted"
+  },
+  {
+    "id": "Chapter1/Section1_2_Intro",
+    "status": "extracted"
+  },
+  {
+    "id": "Chapter1/Definition1_2",
+    "status": "extracted"
+  },
+  {
+    "id": "Chapter1/Example1_3",
+    "status": "extracted"
+  },
+  {
+    "id": "Chapter1/Lemma1_4",
+    "status": "extracted"
+  },
+  {
+    "id": "Chapter1/Corollary1_5",
+    "status": "extracted"
+  },
+  {
+    "id": "Chapter1/Definition1_6",
+    "status": "extracted"
+  },
+  {
+    "id": "Chapter1/Section1_3_Intro",
+    "status": "extracted"
+  },
+  {
+    "id": "Chapter1/Definition1_7",
+    "status": "extracted"
+  },
+  {
+    "id": "Chapter1/Theorem1_8",
+    "status": "extracted"
+  },
+  {
+    "id": "Chapter1/Theorem1_9",
+    "status": "extracted"
+  },
+  {
+    "id": "Chapter1/Section1_4_Intro",
+    "status": "extracted"
+  },
+  {
+    "id": "Chapter1/Definition1_10",
+    "status": "extracted"
+  },
+  {
+    "id": "Chapter1/Discussion_after_Definition1_10",
+    "status": "extracted"
+  },
+  {
+    "id": "Chapter1/Definition1_11",
+    "status": "extracted"
+  },
+  {
+    "id": "Chapter1/Discussion_after_Definition1_11",
+    "status": "extracted"
+  },
+  {
+    "id": "Chapter1/Definition1_12",
+    "status": "extracted"
+  },
+  {
+    "id": "Chapter1/Definition1_13",
+    "status": "extracted"
+  },
+  {
+    "id": "Chapter1/Discussion_after_Definition1_13",
+    "status": "extracted"
+  },
+  {
+    "id": "Chapter1/Example1_14",
+    "status": "extracted"
+  },
+  {
+    "id": "Chapter1/Example1_15",
+    "status": "extracted"
+  },
+  {
+    "id": "Chapter1/Section1_5_Intro",
+    "status": "extracted"
+  },
+  {
+    "id": "Chapter1/Theorem1_16",
+    "status": "extracted"
+  },
+  {
+    "id": "Chapter1/Section1_6_Intro",
+    "status": "extracted"
+  },
+  {
+    "id": "Chapter1/Definition1_17",
+    "status": "extracted"
+  },
+  {
+    "id": "Chapter1/Proposition1_18",
+    "status": "extracted"
+  },
+  {
+    "id": "Chapter1/Definition1_19",
+    "status": "extracted"
+  },
+  {
+    "id": "Chapter1/Proposition1_20",
+    "status": "extracted"
+  },
+  {
+    "id": "Chapter1/Corollary1_21",
+    "status": "extracted"
+  },
+  {
+    "id": "Chapter1/Proposition1_22",
+    "status": "extracted"
+  },
+  {
+    "id": "Chapter1/Corollary1_23",
+    "status": "extracted"
+  },
+  {
+    "id": "Chapter1/Example1_24",
+    "status": "extracted"
+  },
+  {
+    "id": "Chapter1/Discussion_after_Example1_24",
+    "status": "extracted"
+  },
+  {
+    "id": "Chapter1/Proposition1_25",
+    "status": "extracted"
+  },
+  {
+    "id": "Chapter1/Definition1_26",
+    "status": "extracted"
+  },
+  {
+    "id": "Chapter1/Remark1_27",
+    "status": "extracted"
+  },
+  {
+    "id": "Chapter1/Proposition1_28",
+    "status": "extracted"
+  },
+  {
+    "id": "Chapter1/Example1_29",
+    "status": "extracted"
+  },
+  {
+    "id": "Chapter1/References",
+    "status": "extracted"
+  }
 ]


### PR DESCRIPTION
Closes #8

Session: `3a59739b-08fc-4954-a572-f5fc261f4174`

490cf16 feat: Stages 2.5-2.6 — readiness report and reference attachment (closes #8)

🤖 Prepared with Claude Code