### PR TITLE
feat: Fill zsqrtd5_not_integrallyClosed proof (Stage 3.3)

### DIFF
--- a/SutherlandNumberTheoryLecture1Draft2/Chapter1/Example1_24.lean
+++ b/SutherlandNumberTheoryLecture1Draft2/Chapter1/Example1_24.lean
@@ -1,6 +1,7 @@
 import SutherlandNumberTheoryLecture1Draft2.Chapter1.Definition1_19
 import Mathlib.NumberTheory.Zsqrtd.Basic
 import Mathlib.RingTheory.IntegralClosure.IntegrallyClosed
+import Mathlib.RingTheory.Localization.FractionRing
 import Mathlib.Analysis.SpecialFunctions.Pow.Real
 
 /-!
@@ -30,4 +31,61 @@ theorem goldenRatio_isIntegral :
 /-- `ℤ[√5]` is not integrally closed (Example 1.24). -/
 theorem zsqrtd5_not_integrallyClosed :
     ¬IsIntegrallyClosed (Zsqrtd 5) := by
-  sorry
+  -- 5 : ℕ is not a perfect square; needed for IsDomain (Zsqrtd 5) and Field (FractionRing ...)
+  haveI h5ns : Zsqrtd.Nonsquare 5 := ⟨fun n h => by
+    have h1 : n ≤ 2 := by nlinarith [Nat.zero_le n]
+    linarith [Nat.mul_le_mul h1 h1]⟩
+  -- Lean doesn't auto-unify (5 : ℤ) with ↑(5 : ℕ), so provide IsDomain explicitly
+  haveI hdom : IsDomain (Zsqrtd 5) :=
+    show IsDomain (Zsqrtd (↑(5 : ℕ))) from inferInstance
+  -- 2 is nonzero in FractionRing (Zsqrtd 5)
+  have h2mem : (2 : Zsqrtd 5) ∈ nonZeroDivisors (Zsqrtd 5) :=
+    mem_nonZeroDivisors_of_ne_zero (by decide)
+  have h2ne : (2 : FractionRing (Zsqrtd 5)) ≠ 0 := by
+    have : algebraMap (Zsqrtd 5) (FractionRing (Zsqrtd 5)) 2 = 2 := map_ofNat _ _
+    rw [← this]
+    exact IsFractionRing.to_map_ne_zero_of_mem_nonZeroDivisors h2mem
+  intro hIC
+  -- φ = (1+√5)/2 in FractionRing (ℤ[√5]), satisfies φ²-φ-1=0
+  set φ : FractionRing (Zsqrtd 5) :=
+    algebraMap (Zsqrtd 5) (FractionRing (Zsqrtd 5)) ⟨1, 1⟩ / (2 : FractionRing (Zsqrtd 5))
+    with hφ_def
+  -- φ is integral over ℤ[√5] (satisfies the monic polynomial X²-X-1)
+  have hφ_int : IsIntegral (Zsqrtd 5) φ := by
+    refine ⟨Polynomial.X ^ 2 - Polynomial.X - 1, ?_, ?_⟩
+    · -- Monic: the leading coefficient of X²-X-1 over Zsqrtd 5 is 1
+      unfold Polynomial.Monic Polynomial.leadingCoeff
+      have hdeg : (Polynomial.X ^ 2 - Polynomial.X - 1 : Polynomial (Zsqrtd 5)).natDegree = 2 := by
+        compute_degree!
+      rw [hdeg]
+      simp [Polynomial.coeff_sub, Polynomial.coeff_X_pow, Polynomial.coeff_X, Polynomial.coeff_one]
+    · -- eval₂ (algebraMap) φ (X²-X-1) = φ²-φ-1 = 0; clear denominators
+      simp only [Polynomial.eval₂_sub, Polynomial.eval₂_pow, Polynomial.eval₂_X,
+                 Polynomial.eval₂_one]
+      rw [hφ_def]
+      -- φ²-φ-1 = 0; clear denominators
+      field_simp [h2ne]
+      -- Goal: a*(a-2) - 2² = 2²*0, i.e., a²-2a-4=0, where a = algebraMap ⟨1,1⟩
+      -- ⟨1,1⟩²-2*⟨1,1⟩-4 = ⟨6,2⟩-⟨2,2⟩-⟨4,0⟩ = ⟨0,0⟩ = 0 in Zsqrtd 5
+      have key : (algebraMap (Zsqrtd 5) (FractionRing (Zsqrtd 5)) ⟨1, 1⟩) ^ 2 -
+                 2 * algebraMap (Zsqrtd 5) (FractionRing (Zsqrtd 5)) ⟨1, 1⟩ - 4 = 0 := by
+        have hval : (⟨1, 1⟩ : Zsqrtd 5) ^ 2 - 2 * ⟨1, 1⟩ - 4 = 0 := by decide
+        have h := congr_arg (algebraMap (Zsqrtd 5) (FractionRing (Zsqrtd 5))) hval
+        simp only [map_sub, map_pow, map_mul, map_ofNat, map_zero] at h
+        exact h
+      linear_combination key
+  -- By IsIntegrallyClosed, φ is in the image of algebraMap
+  rw [IsIntegrallyClosed.isIntegral_iff] at hφ_int
+  obtain ⟨y, hy⟩ := hφ_int
+  -- From hy: algebraMap y = algebraMap ⟨1,1⟩ / 2, so 2*y = ⟨1,1⟩ in Zsqrtd 5
+  have h2y : (2 : Zsqrtd 5) * y = ⟨1, 1⟩ := by
+    apply IsFractionRing.injective (Zsqrtd 5) (FractionRing (Zsqrtd 5))
+    rw [map_mul, hy, hφ_def]
+    -- Goal: algebraMap 2 * (algebraMap ⟨1,1⟩ / 2) = algebraMap ⟨1,1⟩
+    rw [show algebraMap (Zsqrtd 5) (FractionRing (Zsqrtd 5)) 2 = 2 from map_ofNat _ _]
+    field_simp [h2ne]
+  -- But 2*y.re = 1 in ℤ is impossible
+  have hre := congr_arg Zsqrtd.re h2y
+  simp only [Zsqrtd.re_mul, Zsqrtd.re_ofNat, Zsqrtd.im_ofNat,
+             mul_zero, zero_mul, add_zero] at hre
+  omega

--- a/progress/2026-03-25T13-00-00Z_450bf195.md
+++ b/progress/2026-03-25T13-00-00Z_450bf195.md
@@ -1,0 +1,42 @@
+## Accomplished
+
+Stage 3.3: Filled `zsqrtd5_not_integrallyClosed` proof in `Example1_24.lean` (issue #35).
+
+- `goldenRatio_isIntegral` was already proved (no change needed)
+- `zsqrtd5_not_integrallyClosed` had a `sorry`; filled with a complete proof:
+  - `Zsqrtd.Nonsquare 5` proved manually (5 is not a perfect square)
+  - `IsDomain (Zsqrtd 5)` provided explicitly via `show IsDomain (Zsqrtd (↑(5 : ℕ)))` to work around Lean's failure to unify `(5 : ℤ)` with `↑(5 : ℕ)` for typeclass synthesis
+  - `2 ≠ 0` in `FractionRing (Zsqrtd 5)` proved via `IsFractionRing.to_map_ne_zero_of_mem_nonZeroDivisors`
+  - Monic proof: `compute_degree!` + `simp [coeff_sub, coeff_X_pow, coeff_X, coeff_one]`
+  - Polynomial evaluation: `simp [eval₂_sub, eval₂_pow, eval₂_X, eval₂_one]` + `field_simp` + `linear_combination` using `congr_arg algebraMap` on `⟨1,1⟩²-2⟨1,1⟩-4=0` in `Zsqrtd 5` (by `decide`)
+  - Contradiction: `congr_arg Zsqrtd.re` + `omega`
+- `Example1_29.lean` was already `sorry_free` (verified, no changes)
+- Updated `progress/items.json`: `Example1_24` → `sorry_free`
+
+Key technical insights:
+- `Polynomial.Monic.decidable` gets stuck in the kernel for `Zsqrtd` polynomials; use `compute_degree! + simp` instead
+- `(Zsqrtd 5)[X]` is parsed as array indexing; use `Polynomial (Zsqrtd 5)` instead
+- `field_simp` expands `a^2` to `a*(a-2)` form; use `linear_combination` rather than `rw [(map_pow).symm]`
+
+## Current frontier
+
+Stage 3.3 item complete. Next items to prove: `Theorem1_16`, `Corollary1_23`, `Proposition1_20`, `Proposition1_25`.
+
+## Overall project progress
+
+- Stages 1.1–3.2: complete
+- Stage 3.1: complete — 28/28 items scaffolded
+- Stage 3.2: complete — 28/28 items `definition_verified`
+- Proof work: 8/28 items fully proved (Theorem1_8, Theorem1_9, Corollary1_21, Proposition1_18, Proposition1_22, Remark1_27, Example1_24, Example1_29); 10/28 have proof sorries; 10/28 are pure definitions
+
+## Next step
+
+Continue Stage 3.3 proof-filling. Recommended next:
+1. `Proposition1_20` — `Algebra.IsIntegral.trans` (1-line proof)
+2. `Proposition1_25` — `ValuationRing.isIntegrallyClosed` instance (1-line proof)
+3. `Corollary1_23` — UFDs integrally closed (Mathlib instance)
+4. `Theorem1_16` — assemble DVR ↔ local PID from Mathlib
+
+## Blockers
+
+None.

--- a/progress/items.json
+++ b/progress/items.json
@@ -129,7 +129,7 @@
   },
   {
     "id": "Chapter1/Example1_24",
-    "status": "definition_verified"
+    "status": "sorry_free"
   },
   {
     "id": "Chapter1/Discussion_after_Example1_24",


### PR DESCRIPTION
Closes #35

Session: `450bf195-97db-46c6-a673-8d3c0cfe549d`

ca93290 feat: Fill zsqrtd5_not_integrallyClosed proof (Stage 3.3, issue #35)

🤖 Prepared with Claude Code