### PR TITLE
## Summary

- Add 6 declarations to `01_10_Definition.lean`: `Valuation` recall, `valueGroup` recall, `IsRankOneDiscrete` example, `not_isField` recall, valuation→absolute value documentation, cross-reference comments
- Add `Rat.AbsoluteValue.padic` recall to `01_07_Definition.lean`
- `lake build` succeeds with zero errors

Closes #81

🤖 Prepared with Claude Code

### DIFF
--- a/SutherlandNumberTheoryLecture1/Chapter1/01_07_Definition.lean
+++ b/SutherlandNumberTheoryLecture1/Chapter1/01_07_Definition.lean
@@ -21,3 +21,6 @@ recall padicValRat (p : ℕ) (q : ℚ) : ℤ
 
 /-- **Definition 1.7.** The `p`-adic norm `|x|ₚ = p ^ (-vₚ(x))` as a rational number. -/
 recall padicNorm (p : ℕ) (q : ℚ) : ℚ
+
+/-- **Definition 1.7.** The `p`-adic absolute value `|x|ₚ` bundled as `AbsoluteValue ℚ ℝ`. -/
+recall Rat.AbsoluteValue.padic (p : ℕ) [Fact p.Prime] : AbsoluteValue ℚ ℝ

--- a/SutherlandNumberTheoryLecture1/Chapter1/01_10_Definition.lean
+++ b/SutherlandNumberTheoryLecture1/Chapter1/01_10_Definition.lean
@@ -3,6 +3,8 @@ import Mathlib.RingTheory.Valuation.Basic
 import Mathlib.RingTheory.DiscreteValuationRing.Basic
 import Mathlib.RingTheory.Valuation.Integers
 import Mathlib.RingTheory.Valuation.ValuationRing
+import Mathlib.RingTheory.Valuation.Discrete.Basic
+import Mathlib.Algebra.GroupWithZero.Range
 
 /-!
 ## Definition 1.10 — Valuations, Value Groups, Valuation Rings, and DVRs
@@ -21,14 +23,39 @@ of its fraction field for a discrete valuation.
 ### Mathlib correspondence
 
 - `Valuation k Γ₀` — a valuation on `k` with values in a linearly ordered group with zero
+- `Valuation.valueGroup v` — the value group (smallest subgroup of `Γˣ` containing the range)
+- `ValueGroup₀ v` — the value group with zero adjoined
+- `Valuation.IsRankOneDiscrete v` — discrete valuation (value group is cyclic and nontrivial)
 - `IsDiscreteValuationRing A` — `A` is a local PID that is not a field
   (equivalent to being the valuation ring of a discrete valuation on `Frac(A)`)
 - `Valuation.integer v` — the valuation ring `{x | v x ≤ 1}`
+- `IsDiscreteValuationRing.not_isField` — a DVR cannot be a field
+- The textbook's DVR definition (valuation ring of a discrete valuation on `Frac(A)`)
+  is equivalent to Mathlib's (local PID, not a field); see `sutherland_theorem1_16`
+  in `01_16_Theorem.lean`.
 -/
 
 /-- **Definition 1.10** (valuation). A valuation on a field in the additive convention. -/
 recall AddValuation (R : Type*) [Ring R] (Γ₀ : Type*)
     [LinearOrderedAddCommMonoidWithTop Γ₀] : Type _
+
+/-- **Definition 1.10** (valuation, multiplicative). A valuation `v : R → Γ₀` in the
+multiplicative convention, mapping into a linearly ordered group with zero.
+We extend `v` to all of `k` by `v(0) = 0` (which corresponds to `v(0) = ∞` in the
+additive convention). -/
+recall Valuation (R : Type*) (Γ₀ : Type*)
+    [LinearOrderedCommMonoidWithZero Γ₀] [Ring R] : Type _
+
+/-- **Definition 1.10** (value group). The smallest subgroup of `Γˣ` containing the
+image of a monoid-with-zero homomorphism. For a valuation `v`, this is the value group. -/
+recall MonoidWithZeroHom.valueGroup {A : Type*} {B : Type*} {F : Type*}
+    [FunLike F A B] (f : F) [MonoidWithZero A] [MonoidWithZero B]
+    [MonoidWithZeroHomClass F A B] : Subgroup Bˣ
+
+/-- **Definition 1.10** (discrete valuation). A valuation is discrete if its value group
+is cyclic and nontrivial — equivalently, isomorphic to `ℤ`. -/
+example (R : Type*) (Γ₀ : Type*) [CommRing R] [LinearOrderedCommGroupWithZero Γ₀]
+    (v : Valuation R Γ₀) [Valuation.IsRankOneDiscrete v] : True := trivial
 
 /-- **Definition 1.10** (DVR). A *discrete valuation ring* is an integral domain that is
 a local PID and not a field. -/
@@ -37,3 +64,21 @@ recall IsDiscreteValuationRing (R : Type*) [CommRing R] [IsDomain R] : Prop
 /-- **Definition 1.10** (valuation ring). For every element of `Frac(A)`, either it or its
 inverse lies in `A`. -/
 recall ValuationRing (A : Type*) [CommRing A] [IsDomain A] : Prop
+
+/-- **Definition 1.10** (DVR is not a field). A discrete valuation ring cannot be a field,
+since `v(Frac A) = ℤ ≠ ℤ≥0 = v(A)`. -/
+recall IsDiscreteValuationRing.not_isField {R : Type*} [CommRing R] [IsDomain R]
+    [IsDiscreteValuationRing R] : ¬IsField R
+
+section ValuationToAbsoluteValue
+
+/-! ### Construction: valuation → nonarchimedean absolute value
+
+Given a valuation `v` on a field `k` and `0 < c < 1`, the map `|x|_v = c^{v(x)}`
+defines a nonarchimedean absolute value. This construction is not directly bundled
+in Mathlib, but the key ingredient is `Valuation.RankOne` which provides an embedding
+of the value group into `ℝ≥0`, effectively giving the same construction.
+
+See `Mathlib.RingTheory.Valuation.RankOne` for the `Valuation.RankOne` class. -/
+
+end ValuationToAbsoluteValue

--- a/progress/2026-03-25T22-48-15Z_0ddcb3fa.md
+++ b/progress/2026-03-25T22-48-15Z_0ddcb3fa.md
@@ -1,0 +1,36 @@
+## Accomplished
+
+Completed issue #81: added all 7 missing declarations to `01_10_Definition.lean` and `01_07_Definition.lean`.
+
+### 01_10_Definition.lean (6 additions)
+1. **`Valuation` recall** — multiplicative valuation with extension to `v(0) = 0`
+2. **`MonoidWithZeroHom.valueGroup` recall** — value group (image of `v` in `Γˣ`)
+3. **`Valuation.IsRankOneDiscrete` example** — discrete valuation (cyclic value group ≅ ℤ)
+4. **Valuation → absolute value section** — documents the `c^{v(x)}` construction and points to `Valuation.RankOne`
+5. **`IsDiscreteValuationRing.not_isField` recall** — DVR cannot be a field
+6. **Cross-reference comments** in docstring — DVR equivalence (`sutherland_theorem1_16`) and textbook vs Mathlib definition difference
+
+### 01_07_Definition.lean (1 addition)
+7. **`Rat.AbsoluteValue.padic` recall** — p-adic absolute value bundled as `AbsoluteValue ℚ ℝ`
+
+`lake build` succeeds with zero errors.
+
+## Current frontier
+
+Issue #81 done. Remaining unclaimed coverage gap issues: #76, #77, #79, #82.
+
+## Overall project progress
+
+- Stages 1.1–2.6: complete
+- Stage 3.1: complete — 28/28 items scaffolded
+- Stage 3.2: in progress — core valuation definitions (#81) now complete
+- Coverage gaps being addressed via issues #76, #77, #79, #82
+
+## Next step
+
+Work on #82 (01_10a_Discussion: valuation ring properties) — it depends on #81 which is now done.
+Alternatively #79 (01_27_Remark: order definition) has no dependencies.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #--title

Session: `0ddcb3fa-a20e-4a88-b759-05628ecb53bc`

3c44fb0 feat: add core valuation definitions and p-adic absolute value (#81)

🤖 Prepared with Claude Code