### PR TITLE
Coverage gap: 01_27_Remark — order definition and maximal order missing

### DIFF
--- a/SutherlandNumberTheoryLecture1/Chapter1/01_27_Remark.lean
+++ b/SutherlandNumberTheoryLecture1/Chapter1/01_27_Remark.lean
@@ -1,19 +1,23 @@
 import Mathlib.Tactic.Recall
 import Mathlib.NumberTheory.NumberField.Basic
 import Mathlib.LinearAlgebra.Dimension.Free
+import Mathlib.RingTheory.IntegralClosure.Algebra.Basic
 
 /-!
-## Remark 1.27 — 𝒪_K as a Free ℤ-Module
+## Remark 1.27 — 𝒪_K as a Free ℤ-Module and Maximal Order
 
 **Remark 1.27.** The notation `ℤ_K` is also used for the ring of integers of `K`.
 The symbol `𝒪` emphasizes that `𝒪_K` is the *maximal order* of `K`.
 In any `ℚ`-algebra `K` of dimension `r`, an *order* is a subring that is also a free
-`ℤ`-module of rank `r`. In particular, `𝒪_K` is a free `ℤ`-module of rank `[K : ℚ]`.
+`ℤ`-module of rank `r`, equivalently a `ℤ`-lattice in `K` that is also a ring.
+In particular, `𝒪_K` is a free `ℤ`-module of rank `[K : ℚ]`, and it is the maximal
+order: it contains every order in `K`.
 
 ### Mathlib correspondence
 
 The freeness is automatic (`Module.Free ℤ (𝓞 K)` is an instance).
 The rank equality is `NumberField.RingOfIntegers.rank`.
+The order definition is not in Mathlib; we define it here as `NumberField.Order`.
 -/
 
 /-- **Remark 1.27.** `𝓞 K` is a free `ℤ`-module. -/
@@ -23,3 +27,30 @@ example {K : Type*} [Field K] [NumberField K] :
 /-- **Remark 1.27.** The `ℤ`-rank of `𝓞 K` equals `[K : ℚ]`. -/
 recall NumberField.RingOfIntegers.rank (K : Type*) [Field K] [NumberField K] :
     Module.finrank ℤ (NumberField.RingOfIntegers K) = Module.finrank ℚ K
+
+/-! ### Order definition
+
+An *order* in a number field `K` is a subring of `K` that is also a free `ℤ`-module
+of rank `[K : ℚ]`. The equivalent description as a "ℤ-lattice in K that is also a ring"
+is just a restatement in lattice-theoretic language and is not separately formalized. -/
+
+/-- An **order** in a number field `K` is a subring of `K` that is a free `ℤ`-module
+of rank `[K : ℚ]`. -/
+structure NumberField.Order (K : Type*) [Field K] [NumberField K] where
+  /-- The underlying subring of `K`. -/
+  carrier : Subring K
+  /-- The subring is a free `ℤ`-module. -/
+  free : Module.Free ℤ carrier
+  /-- The `ℤ`-rank equals `[K : ℚ]`. -/
+  rank_eq : Module.finrank ℤ carrier = Module.finrank ℚ K
+
+/-! ### 𝒪_K is the maximal order
+
+Every element of an order is integral over `ℤ` (since it lies in a finitely generated
+`ℤ`-module), hence belongs to the integral closure `𝒪_K`. -/
+
+/-- **Remark 1.27.** `𝒪_K` is the maximal order: every order in `K` is contained in `𝒪_K`. -/
+theorem NumberField.Order.le_ringOfIntegers {K : Type*} [Field K] [NumberField K]
+    (O : NumberField.Order K) (x : K) (hx : x ∈ O.carrier) :
+    x ∈ (algebraMap (NumberField.RingOfIntegers K) K).range := by
+  sorry

--- a/progress/2026-03-25T22-45-00Z_0d5a3b8b.md
+++ b/progress/2026-03-25T22-45-00Z_0d5a3b8b.md
@@ -1,0 +1,28 @@
+## Accomplished
+
+- Claimed and completed issue #79 (coverage gap: 01_27_Remark)
+- Added `NumberField.Order` structure definition (subring + free ℤ-module of rank [K:ℚ])
+- Added ℤ-lattice equivalence as documentation-only comment (lattice language is a restatement)
+- Stated `NumberField.Order.le_ringOfIntegers` theorem (𝒪_K is maximal order) with sorry'd proof
+- Added import for `Mathlib.RingTheory.IntegralClosure.Algebra.Basic` (provides `isIntegral_of_noetherian` for proof route)
+- `lake build` succeeds with only the expected sorry warning
+
+## Current frontier
+
+Issue #79 complete. The sorry'd maximality proof has a clear route: free + finite rank ℤ-module ⇒ Noetherian ⇒ isIntegral ⇒ in integral closure.
+
+## Overall project progress
+
+- Stages 1.1–1.6 ✅ (structure analysis, blob extraction)
+- Stages 2.1–2.4 ✅ (dependency analysis, Mathlib coverage)
+- Stage 3 (formalization): scaffolding in progress
+  - Coverage gap remediation: #79 done, #76 and #77 blocked on dependencies (#75, #81)
+
+## Next step
+
+- Issues #76 and #77 are blocked on #75 and #81 respectively
+- Check if #75 or #81 have PRs ready to merge, or if other unclaimed work exists
+
+## Blockers
+
+None for this turn. Remaining coverage gap issues (#76, #77) are blocked on upstream dependencies.

--- a/progress/items.json
+++ b/progress/items.json
@@ -174,8 +174,8 @@
   },
   {
     "id": "Chapter1/01_27_Remark",
-    "status": "needs_scaffolding",
-    "reason": "coverage gap: order definition (subring + free ℤ-module) and maximality of 𝒪_K not formalized"
+    "status": "scaffolded",
+    "reason": "Order definition added, maximality theorem stated with sorry"
   },
   {
     "id": "Chapter1/01_28_Proposition",


### PR DESCRIPTION
Closes #79

Session: `0d5a3b8b-85ed-4007-8d62-8c89dfaaf8f5`

8dc3e84 feat: add NumberField.Order definition and maximality theorem (#79)

🤖 Prepared with Claude Code