### PR TITLE
Prove 01_27_Remark: NumberField.Order.le_ringOfIntegers

### DIFF
--- a/SutherlandNumberTheoryLecture1/Chapter1/01_27_Remark.lean
+++ b/SutherlandNumberTheoryLecture1/Chapter1/01_27_Remark.lean
@@ -53,4 +53,9 @@ Every element of an order is integral over `ℤ` (since it lies in a finitely ge
 theorem NumberField.Order.le_ringOfIntegers {K : Type*} [Field K] [NumberField K]
     (O : NumberField.Order K) (x : K) (hx : x ∈ O.carrier) :
     x ∈ (algebraMap (NumberField.RingOfIntegers K) K).range := by
-  sorry
+  haveI := O.free
+  have hfin : Module.Finite ℤ O.carrier :=
+    Module.finite_of_finrank_pos (O.rank_eq ▸ Module.finrank_pos (R := ℚ) (M := K))
+  have hint : IsIntegral ℤ (⟨x, hx⟩ : O.carrier) := IsIntegral.of_finite ℤ _
+  rw [RingHom.mem_range]
+  exact IsIntegralClosure.isIntegral_iff.mp (hint.algebraMap (R := ℤ))

--- a/progress/2026-03-25T23-15-00Z.md
+++ b/progress/2026-03-25T23-15-00Z.md
@@ -1,0 +1,27 @@
+## Accomplished
+
+- Proved `NumberField.Order.le_ringOfIntegers` in `01_27_Remark.lean` — the last `sorry` in the codebase
+- Proof strategy: free ℤ-module of finite rank → Module.Finite → IsIntegral → in integral closure = 𝓞 K
+- Updated `progress/items.json`: `01_27_Remark` → `proof_polished`
+- Verified: zero `sorry` across all `.lean` files, `lake build` succeeds
+
+## Current frontier
+
+All proofs complete. Zero sorries remain.
+
+## Overall project progress
+
+- Stages 1.1–1.6: Complete (PDF extraction, transcription, structure analysis, blob extraction)
+- Stages 2.1–2.4: Complete (dependency analysis, Mathlib coverage research)
+- Stage 3: All 40 items formalized, all proofs sorry-free
+- The codebase builds cleanly with zero errors
+
+## Next step
+
+- Issue #94 (final coverage audit) is the natural next step
+- Verify all items in `items.json` have accurate status
+- Close remaining open issues
+
+## Blockers
+
+None.

--- a/progress/items.json
+++ b/progress/items.json
@@ -174,8 +174,8 @@
   },
   {
     "id": "Chapter1/01_27_Remark",
-    "status": "scaffolded",
-    "reason": "Order definition added, maximality theorem stated with sorry"
+    "status": "proof_polished",
+    "reason": "Order definition and maximality theorem fully proved"
   },
   {
     "id": "Chapter1/01_28_Proposition",


### PR DESCRIPTION
Closes #93

Session: `e86dd5a2-4cfa-4b17-976e-26b95cd7de4d`

3fd6cd9 feat: prove NumberField.Order.le_ringOfIntegers — last sorry eliminated (#93)

🤖 Prepared with Claude Code