### PR TITLE
## Summary
- Replace deprecated `Nat.factorization_prod_pow_eq_self` with `Nat.prod_factorization_pow_eq_self` in `01_09_Theorem.lean`
- Eliminates the deprecation warning identified in the proof quality audit (#100)

## Verification
- `lake build` passes with zero warnings

🤖 Prepared with Claude Code

### DIFF
--- a/SutherlandNumberTheoryLecture1/Chapter1/01_09_Theorem.lean
+++ b/SutherlandNumberTheoryLecture1/Chapter1/01_09_Theorem.lean
@@ -47,7 +47,7 @@ private lemma fta_prod_nat (n : ℕ) (hn : n ≠ 0) :
   have h_eq : ∀ p ∈ n.primeFactors, p ^ padicValNat p n = p ^ n.factorization p :=
     fun p hp => by rw [Nat.factorization_def n (Nat.prime_of_mem_primeFactors hp)]
   rw [Finset.prod_congr rfl h_eq]
-  exact Nat.factorization_prod_pow_eq_self hn
+  exact Nat.prod_factorization_pow_eq_self hn
 
 private lemma fta_prod_rat (n : ℕ) (hn : n ≠ 0) :
     ∏ p ∈ n.primeFactors, (p : ℚ) ^ padicValNat p n = (n : ℚ) := by


### PR DESCRIPTION
Closes #--issue

Session: `8c7c658d-2a5c-4017-8bdb-febab09703cb`

22769b4 fix: replace deprecated Nat.factorization_prod_pow_eq_self (#109)

🤖 Prepared with Claude Code