### PR TITLE
01_15: order-of-vanishing valuation on k((t)) not connected to ValuationRing k⟦X⟧

### DIFF
--- a/SutherlandNumberTheoryLecture1/Chapter1/01_15_Example.lean
+++ b/SutherlandNumberTheoryLecture1/Chapter1/01_15_Example.lean
@@ -5,6 +5,7 @@ import Mathlib.RingTheory.DiscreteValuationRing.Basic
 import Mathlib.RingTheory.PowerSeries.Inverse
 import Mathlib.RingTheory.Valuation.ValuationRing
 import Mathlib.RingTheory.PowerSeries.Order
+import Mathlib.RingTheory.LaurentSeries
 
 /-!
 ## Example 1.15 — Power Series Ring as DVR
@@ -13,10 +14,14 @@ import Mathlib.RingTheory.PowerSeries.Order
 fraction field `k((t))` (Laurent series). The valuation `v : k((t)) → ℤ ∪ {∞}` sends
 `∑_{n ≥ n₀} aₙ tⁿ` (with `a_{n₀} ≠ 0`) to `n₀`. The valuation ring is `k[[t]]`.
 
-In Mathlib, the DVR instance for `k⟦X⟧` is automatic. The valuation on `k⟦X⟧` is
-`PowerSeries.order`, which gives the multiplicity of `X` in `φ` — equivalently,
-the index of the first nonzero coefficient. For `f ∈ k((t))×`, the valuation `v(f)`
-is the *order of vanishing* of `f` at zero.
+### Formalization strategy
+
+The DVR and valuation ring instances for `k⟦X⟧` are automatic in Mathlib.
+The X-adic valuation on Laurent series `k⸨X⸩` is provided by
+`Valued K⸨X⸩ ℤᵐ⁰` (built from `PowerSeries.idealX`). The key connection —
+that the valuation ring of this valuation is exactly `k⟦X⟧` — is
+`LaurentSeries.val_le_one_iff_eq_coe`: a Laurent series has valuation ≤ 1
+if and only if it is the image of a power series.
 -/
 
 open PowerSeries in
@@ -29,31 +34,72 @@ set_option backward.isDefEq.respectTransparency false in
 /-- **Example 1.15.** `k⟦X⟧` is also a valuation ring. -/
 example {k : Type*} [Field k] : ValuationRing k⟦X⟧ := inferInstance
 
-/-! ### The valuation on k⟦X⟧
+/-! ### The X-adic valuation on Laurent series
 
-The valuation `v(∑ aₙ Xⁿ) = n₀` where `a_{n₀} ≠ 0` is `PowerSeries.order` in Mathlib.
-It is the greatest `n` such that `X^n` divides `φ`, equivalently the index of the
-first nonzero coefficient. For nonzero `f`, this is the *order of vanishing* of `f`
-at zero: the multiplicity of `X` as a factor.
+Mathlib equips the Laurent series field `k⸨X⸩` with the X-adic valuation via
+the `Valued` instance, built from the height-one-spectrum valuation of the
+prime ideal `(X) ⊂ k⟦X⟧`. For a power series `f`, the valuation measures
+the X-adic order: the index of the first nonzero coefficient.
 -/
 
--- `PowerSeries.order φ` is the greatest `n : ℕ∞` such that `X^n ∣ φ`.
--- This is the valuation `v(φ) = n₀` from Example 1.15: for `φ = ∑_{n ≥ n₀} aₙ Xⁿ`
--- with `a_{n₀} ≠ 0`, `order φ = n₀`. The order is `⊤` iff `φ = 0`.
+open scoped LaurentSeries WithZero in
+/-- The Laurent series field `k⸨X⸩` carries a canonical X-adic valuation with values in `ℤᵐ⁰`. -/
+noncomputable example (k : Type*) [Field k] : Valued k⸨X⸩ ℤᵐ⁰ := inferInstance
+
+/-! ### The valuation ring is k⟦X⟧
+
+The mathematical content of Example 1.15: the valuation ring of the X-adic
+valuation on `k((t))` is exactly `k[[t]]`. In Mathlib this is
+`LaurentSeries.val_le_one_iff_eq_coe`: a Laurent series `f` satisfies
+`v(f) ≤ 1` if and only if `f` comes from a power series.
+-/
+
+open scoped LaurentSeries WithZero in
+open PowerSeries in
+set_option backward.isDefEq.respectTransparency false in
+/-- **Example 1.15 (key result).** The valuation ring of the X-adic valuation on `k⸨X⸩`
+is `k⟦X⟧`: a Laurent series has valuation ≤ 1 iff it is (the image of) a power series. -/
+example (k : Type*) [Field k] (f : k⸨X⸩) :
+    Valued.v f ≤ (1 : ℤᵐ⁰) ↔ ∃ F : k⟦X⟧, (F : k⸨X⸩) = f :=
+  LaurentSeries.val_le_one_iff_eq_coe k f
+
+/-! ### The order function as valuation
+
+`PowerSeries.order` gives the valuation `v(φ) = n₀` from Example 1.15: for
+`φ = ∑_{n ≥ n₀} aₙ Xⁿ` with `a_{n₀} ≠ 0`, `order φ = n₀`. The order is `⊤` iff `φ = 0`.
+The order is multiplicative (`order (φ * ψ) = order φ + order ψ`) and equals the
+multiplicity of `X` in `φ`, connecting the valuation-theoretic and algebraic views.
+-/
+
 open PowerSeries in
 recall PowerSeries.order (R : Type*) [Semiring R] (φ : PowerSeries R) : ℕ∞
 
--- `order` is an additive valuation: `order (φ * ψ) = order φ + order ψ`.
 open PowerSeries in
 recall PowerSeries.order_mul (R : Type*) [Semiring R] [NoZeroDivisors R]
   (φ ψ : PowerSeries R) :
   PowerSeries.order (φ * ψ) = PowerSeries.order φ + PowerSeries.order ψ
 
--- The order equals the multiplicity of `X` in `φ`, connecting the
--- valuation-theoretic view with the algebraic notion of multiplicity.
 open PowerSeries in
 recall PowerSeries.order_eq_emultiplicity_X (R : Type*) [Semiring R] (φ : PowerSeries R) :
   PowerSeries.order φ = emultiplicity PowerSeries.X φ
+
+/-! ### The valuation determines the first nonzero coefficient
+
+The X-adic valuation on power series is characterized by the vanishing of coefficients:
+`v(f) ≤ exp(-d)` iff all coefficients below index `d` are zero. This is the precise
+connection between the abstract valuation and the concrete "order of vanishing" from
+the book.
+-/
+
+open scoped LaurentSeries WithZero in
+open PowerSeries WithZero in
+set_option backward.isDefEq.respectTransparency false in
+/-- The valuation of a power series `f` satisfies `v(f) ≤ exp(-d)` iff all
+coefficients of index `< d` vanish — i.e., the order of vanishing is at least `d`. -/
+example (k : Type*) [Field k] {d : ℕ} (f : k⟦X⟧) :
+    Valued.v (f : k⸨X⸩) ≤ Multiplicative.ofAdd (-d : ℤ) ↔
+      ∀ n : ℕ, n < d → coeff n f = 0 :=
+  LaurentSeries.intValuation_le_iff_coeff_lt_eq_zero k f
 
 /-! ### Valuation at other points
 
@@ -63,7 +109,4 @@ about `α`). This corresponds to shifting the indeterminate `X ↦ X - C α` and
 the order. A full formalization would require working with the substitution
 `PowerSeries.map` composed with the shift; this is beyond the scope of Example 1.15
 and is left as documentation-only.
-
--- TODO: v_α formalization would require `PowerSeries.eval` or substitution infrastructure
--- that is not currently available in Mathlib. This is a documentation-only claim.
 -/


### PR DESCRIPTION
Closes #115

Session: `ee8306e2-1e0b-444e-b694-3b5432501207`

798c3f0 01_15: connect order-of-vanishing valuation to ValuationRing k⟦X⟧ (#115)

🤖 Prepared with Claude Code