### PR TITLE
01_06/01_08: prove AreEquivalent ↔ IsEquiv rather than deleting the definition

### DIFF
--- a/SutherlandNumberTheoryLecture1/Chapter1/01_06_Definition.lean
+++ b/SutherlandNumberTheoryLecture1/Chapter1/01_06_Definition.lean
@@ -9,11 +9,33 @@ import Mathlib.Analysis.AbsoluteValue.Equivalence
 ### Mathlib correspondence
 
 Mathlib's `AbsoluteValue.IsEquiv v w` uses an equivalent characterization via
-order-preservation: `∀ x y, v x ≤ v y ↔ w x ≤ w y`. For real-valued absolute values
-on a field, this is equivalent to the book's power-law definition: if one absolute value
-is a positive real power of the other, then they preserve the same ordering, and conversely.
+order-preservation: `∀ x y, v x ≤ v y ↔ w x ≤ w y`. The bridge between the two
+is `AbsoluteValue.isEquiv_iff_exists_rpow_eq`.
 
-We use Mathlib's `AbsoluteValue.IsEquiv` throughout this formalization rather than
-defining a separate notion, since Ostrowski's Theorem (1.8) is proved in Mathlib using
-`IsEquiv`. The book's Definition 1.6 corresponds exactly to `AbsoluteValue.IsEquiv`.
+We prove `AbsoluteValue.AreEquivalent f g ↔ f.IsEquiv g` below.
 -/
+
+open AbsoluteValue in
+/-- **Definition 1.6.** Two absolute values on `k` are *equivalent* if one is a positive
+real power of the other: `∃ α > 0, ∀ x, g x = (f x) ^ α`. -/
+def AbsoluteValue.AreEquivalent {k : Type*} [Field k]
+    (f g : AbsoluteValue k ℝ) : Prop :=
+  ∃ α : ℝ, 0 < α ∧ ∀ x : k, g x = (f x) ^ α
+
+namespace AbsoluteValue
+
+variable {k : Type*} [Field k] {f g : AbsoluteValue k ℝ}
+
+/-- The book's power-law equivalence (Definition 1.6) is equivalent to Mathlib's
+order-preserving equivalence (`IsEquiv`). -/
+theorem areEquivalent_iff_isEquiv : f.AreEquivalent g ↔ f.IsEquiv g := by
+  constructor
+  · rintro ⟨α, hα, hfg⟩
+    rw [isEquiv_iff_exists_rpow_eq]
+    exact ⟨α, hα, funext fun x => (hfg x).symm⟩
+  · intro h
+    rw [isEquiv_iff_exists_rpow_eq] at h
+    obtain ⟨c, hc, hcfg⟩ := h
+    exact ⟨c, hc, fun x => (congr_fun hcfg x).symm⟩
+
+end AbsoluteValue

--- a/SutherlandNumberTheoryLecture1/Chapter1/01_08_Theorem.lean
+++ b/SutherlandNumberTheoryLecture1/Chapter1/01_08_Theorem.lean
@@ -1,5 +1,6 @@
 import Mathlib.Tactic.Recall
 import Mathlib.NumberTheory.Ostrowski
+import SutherlandNumberTheoryLecture1.Chapter1.«01_06_Definition»
 
 /-!
 ## Theorem 1.8 — Ostrowski's Theorem
@@ -8,6 +9,8 @@ import Mathlib.NumberTheory.Ostrowski
 equivalent to `|·|ₚ` for some `p ≤ ∞`.
 
 This is fully proved in Mathlib as `Rat.AbsoluteValue.equiv_real_or_padic`.
+We restate it using the book's `AreEquivalent` (Definition 1.6) via the bridging
+theorem `areEquivalent_iff_isEquiv`.
 -/
 
 /-- **Theorem 1.8** (Ostrowski). Every nontrivial absolute value on `ℚ` is equivalent
@@ -16,3 +19,11 @@ recall Rat.AbsoluteValue.equiv_real_or_padic (f : AbsoluteValue ℚ ℝ)
     (hf : f.IsNontrivial) :
     f.IsEquiv Rat.AbsoluteValue.real ∨
     ∃! p : ℕ, ∃ _ : Fact p.Prime, f.IsEquiv (Rat.AbsoluteValue.padic p)
+
+/-- **Theorem 1.8** restated using the book's Definition 1.6 (`AreEquivalent`). -/
+theorem Rat.AbsoluteValue.areEquivalent_real_or_padic (f : AbsoluteValue ℚ ℝ)
+    (hf : f.IsNontrivial) :
+    f.AreEquivalent Rat.AbsoluteValue.real ∨
+    ∃! p : ℕ, ∃ _ : Fact p.Prime, f.AreEquivalent (Rat.AbsoluteValue.padic p) := by
+  simp only [AbsoluteValue.areEquivalent_iff_isEquiv]
+  exact Rat.AbsoluteValue.equiv_real_or_padic f hf


### PR DESCRIPTION
Closes #121

Session: `1462cc30-ea8f-4d57-b8c7-7ec1fff510e6`

f3b3e0d 01_06/01_08: restore AreEquivalent and prove ↔ IsEquiv (#121)

🤖 Prepared with Claude Code